### PR TITLE
Docker: updates for btcp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:18.04
 
-ENV VERSION 1.0.2
+ENV VERSION 1.0.0
 
 RUN set -x \
     && apt-get update \
     && apt-get install -y curl \
-    && curl -sL https://github.com/BTCP-community/electrum-zcl/archive/Z!${VERSION}.tar.gz |tar xzv \
-    && mv electrum-zcl-Z-${VERSION} electrum-zcl \
-    && cd electrum-zcl \
+    && curl -sL https://github.com/BTCPrivate/electrum-btcp/archive/P!${VERSION}.tar.gz |tar xvz \
+    && mv electrum-btcp-P-${VERSION} electrum-btcp \
+    && cd electrum-btcp \
     && apt-get install -y $(grep -vE "^\s*#" packages.txt  | tr "\n" " ") \
     && pip3 install -r requirements.txt \
     && pip3 install pyblake2 \
@@ -15,7 +15,7 @@ RUN set -x \
     && pyrcc5 icons.qrc -o gui/qt/icons_rc.py \
     && ./contrib/make_locale
 
-WORKDIR /electrum-zcl
+WORKDIR /electrum-btcp
 
 ENV DISPLAY :0
 

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build -t electrum-zcl:latest .
+docker build -t electrum-btcp:latest .

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 XSOCK=/tmp/.X11-unix
 XAUTH=/tmp/.docker.xauth
-DATADIR=.electrum-zcl
+DATADIR=.electrum-btcp
 xauth nlist :0 | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
-docker run -ti -v $HOME/$DATADIR:/root/$DATADIR -v $XSOCK:$XSOCK -v $XAUTH:$XAUTH -e XAUTHORITY=$XAUTH electrum-zcl:latest
+docker run -ti -v $HOME/$DATADIR:/root/$DATADIR -v $XSOCK:$XSOCK -v $XAUTH:$XAUTH -e XAUTHORITY=$XAUTH electrum-btcp:latest


### PR DESCRIPTION
Update the Dockerfile, build and run scripts for btcp electrum wallet. Tested by sweeping ZCL keys used for dev mining pool to claim BTCP.

Signed-off-by: Tyler Baker <tyler@opensourcefoundries.com>