### PR TITLE
Enabled automatic graphics switching

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -18,5 +18,7 @@
     <string>x86_64</string>
     <string>i386</string>
   </array>
+  <key>NSSupportsAutomaticGraphicsSwitching</key>
+  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Enabled automatic graphics switching for lower power consumption when running on mac portables with discrete GPUs.