### PR TITLE
Add support for Ledger Nano S on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ENV VERSION 1.0.0
+ENV VERSION 1.1.1
 
 RUN set -x \
     && apt-get update \
@@ -19,6 +19,4 @@ WORKDIR /electrum-btcp
 
 ENV DISPLAY :0
 
-CMD ./electrum
-
-
+CMD ./electrum-btcp

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Build the docker image::
 Run the docker image::
 
     ./run-docker.sh
-
+(First connect the Ledger to your computer USB port and open the Bitcoin Private app on the Ledger Nano S)
 
 Building Releases
 =================

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -2,5 +2,13 @@
 XSOCK=/tmp/.X11-unix
 XAUTH=/tmp/.docker.xauth
 DATADIR=.electrum-btcp
+LEDGER_USB_ID='2c97:0001'
 xauth nlist :0 | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
-docker run -ti -v $HOME/$DATADIR:/root/$DATADIR -v $XSOCK:$XSOCK -v $XAUTH:$XAUTH -e XAUTHORITY=$XAUTH electrum-btcp:latest
+
+if lsusb -d $LEDGER_USB_ID > /dev/null; then
+  BUS=$(lsusb -d 2c97:0001 | cut -d' ' -f 2)
+  DEVICE=$(lsusb -d 2c97:0001 | cut -d' ' -f 4 | tr -d ':')
+  DOCKER_DEVICE="--device /dev/bus/usb/$BUS/$DEVICE"
+fi
+
+docker run -ti -v $HOME/$DATADIR:/root/$DATADIR -v $XSOCK:$XSOCK -v $XAUTH:$XAUTH -e XAUTHORITY=$XAUTH  $DOCKER_DEVICE electrum-btcp:latest


### PR DESCRIPTION
Adding support for Ledger Nano S on docker build, pointing docker build script to version 1.1.1 and adding `--device` option to `run-docker.sh` script.
Also updated `Readme.rst` to reflect the change.

Fix #88 